### PR TITLE
Unmatched _ sign in U2F Technical Overview

### DIFF
--- a/content/U2F/Protocol_details/Overview.adoc
+++ b/content/U2F/Protocol_details/Overview.adoc
@@ -1,5 +1,5 @@
 == U2F Technical Overview
-U2F is a challenge-response protocol extended with _phishing and abbr:MitM[Man-in-the-Middle] protection, _application-specific keys_, _device cloning detection_ and _device attestation_. There are two flows: _registration_ and _authentication_.
+U2F is a challenge-response protocol extended with _phishing and abbr:MitM[Man-in-the-Middle] protection_, _application-specific keys_, _device cloning detection_ and _device attestation_. There are two flows: _registration_ and _authentication_.
 
 
 === 1. Challenge-response


### PR DESCRIPTION
There's missing `_` in the first term: _phishing and abbr:MitM[Man-in-the-Middle] protection_